### PR TITLE
Added Database

### DIFF
--- a/Controls/Model3DViewer.cs
+++ b/Controls/Model3DViewer.cs
@@ -16,7 +16,6 @@ namespace MauiApp3.Controls
         private Vector2 _panOffset = Vector2.Zero;
         private Vector2? _lastTouchPoint;
         private bool _isRotating;
-        private bool _isPanning;
 
         // Cached objects for performance
         private readonly List<(StlParser.Triangle triangle, float depth, Vector3[] vertices)> _transformedTriangles = new();
@@ -76,7 +75,6 @@ namespace MauiApp3.Controls
                 case SKTouchAction.Cancelled:
                     _lastTouchPoint = null;
                     _isRotating = false;
-                    _isPanning = false;
                     e.Handled = true;
                     break;
 
@@ -216,11 +214,14 @@ namespace MauiApp3.Controls
                 Style = SKPaintStyle.Stroke
             };
 
+            using var font = new SKFont
+            {
+                Size = 12
+            };
+
             using var textPaint = new SKPaint
             {
-                TextSize = 12,
-                IsAntialias = true,
-                TextAlign = SKTextAlign.Center
+                IsAntialias = true
             };
 
             foreach (var (axis, color, label) in axes)
@@ -231,7 +232,7 @@ namespace MauiApp3.Controls
                 canvas.DrawLine(0, 0, transformed.X, -transformed.Y, linePaint);
 
                 textPaint.Color = color;
-                canvas.DrawText(label, transformed.X, -transformed.Y - 5, textPaint);
+                canvas.DrawText(label, transformed.X, -transformed.Y - 5, SKTextAlign.Center, font, textPaint);
             }
 
             canvas.Restore();

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -80,7 +80,7 @@
                             
 
                             <Button Text="📁 Upload Model"
-                                    Command="{Binding UploadModelCommand}"
+                                    Clicked="OnUploadButtonClicked"
                                     BackgroundColor="#0078D4"
                                     TextColor="White"
                                     CornerRadius="6"
@@ -307,7 +307,7 @@
                                    HorizontalOptions="Center"
                                    Margin="0,10,0,0"/>
                             <Button Text="Upload Your First Model"
-                                    Command="{Binding UploadModelCommand}"
+                                    Clicked="OnUploadButtonClicked"
                                     BackgroundColor="#0078D4"
                                     TextColor="White"
                                     Margin="0,20,0,0"

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -13,6 +13,10 @@ namespace MauiApp3
             
             // Subscribe to property changes to update the 3D viewer
             viewModel.PropertyChanged += OnViewModelPropertyChanged;
+            
+            // Log to verify initialization
+            Console.WriteLine($"MainPage: BindingContext set to MainViewModel");
+            Console.WriteLine($"MainPage: UploadModelCommand is null? {viewModel.UploadModelCommand == null}");
         }
 
         private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -38,6 +42,123 @@ namespace MauiApp3
             if (ViewModel.SelectedModel?.ParsedModel != null)
             {
                 Model3DViewer.ResetView();
+            }
+        }
+
+        private async void OnUploadButtonClicked(object sender, EventArgs e)
+        {
+            Console.WriteLine("=== UPLOAD BUTTON CLICKED ===");
+            
+            try
+            {
+                Console.WriteLine("Opening file picker directly...");
+                
+                // Direct FilePicker call
+                var result = await FilePicker.Default.PickAsync(new PickOptions
+                {
+                    PickerTitle = "Select 3D Model File",
+                    FileTypes = new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+                    {
+                        { DevicePlatform.WinUI, new[] { ".stl", ".3mf" } }
+                    })
+                });
+                
+                Console.WriteLine($"File picker result: {result?.FileName ?? "null"}");
+                
+                if (result == null)
+                {
+                    Console.WriteLine("User cancelled file selection");
+                    return;
+                }
+                
+                // File was selected - now process it
+                Console.WriteLine($"Processing file: {result.FileName}");
+                Console.WriteLine($"File path: {result.FullPath}");
+                
+                // Validate file format
+                if (!result.FileName.EndsWith(".stl", StringComparison.OrdinalIgnoreCase) && 
+                    !result.FileName.EndsWith(".3mf", StringComparison.OrdinalIgnoreCase))
+                {
+                    await DisplayAlert("Error", "Please select an STL or 3MF file.", "OK");
+                    return;
+                }
+                
+                // Show loading
+                ViewModel.IsLoading = true;
+                
+                try
+                {
+                    Console.WriteLine("Creating model object...");
+                    var fileInfo = new FileInfo(result.FullPath);
+                    var extension = Path.GetExtension(result.FileName).ToUpperInvariant().TrimStart('.');
+                    
+                    var model = new Models.Model3DFile
+                    {
+                        Name = result.FileName,
+                        FilePath = result.FullPath,
+                        FileType = extension,
+                        FileSize = fileInfo.Length,
+                        UploadedDate = DateTime.Now
+                    };
+                    
+                    Console.WriteLine($"Parsing {extension} file...");
+                    
+                    // Use the Model3DService to load and parse
+                    var model3DService = Handler?.MauiContext?.Services.GetService<Services.Model3DService>();
+                    if (model3DService == null)
+                    {
+                        Console.WriteLine("ERROR: Could not get Model3DService from services");
+                        await DisplayAlert("Error", "Service initialization failed", "OK");
+                        return;
+                    }
+                    
+                    model.ParsedModel = await model3DService.LoadModelAsync(result.FullPath);
+                    
+                    if (model.ParsedModel == null)
+                    {
+                        Console.WriteLine("ERROR: Failed to parse model");
+                        await DisplayAlert("Error", $"Failed to parse {extension} file. The file may be corrupted or invalid.", "OK");
+                        return;
+                    }
+                    
+                    Console.WriteLine($"Successfully parsed {model.ParsedModel.Triangles.Count} triangles");
+                    Console.WriteLine("Generating thumbnail...");
+                    
+                    // Generate thumbnail
+                    model.ThumbnailData = await model3DService.GenerateThumbnailAsync(result.FullPath, model.ParsedModel);
+                    
+                    Console.WriteLine("Adding model to collection...");
+                    
+                    // Add to ViewModel
+                    ViewModel.Models.Add(model);
+                    ViewModel.SelectedModel = model;
+                    
+                    Console.WriteLine("Saving to database...");
+                    
+                    // Save to database
+                    var databaseService = Handler?.MauiContext?.Services.GetService<Services.DatabaseService>();
+                    if (databaseService != null)
+                    {
+                        await databaseService.SaveModelAsync(model);
+                        Console.WriteLine("Saved to database successfully");
+                    }
+                    
+                    Console.WriteLine("Upload complete!");
+                    await DisplayAlert("Success", 
+                        $"Model '{model.Name}' loaded successfully!\n\nTriangles: {model.ParsedModel.Triangles.Count:N0}", 
+                        "OK");
+                }
+                finally
+                {
+                    ViewModel.IsLoading = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR: {ex.Message}");
+                Console.WriteLine($"Stack trace: {ex.StackTrace}");
+                ViewModel.IsLoading = false;
+                await DisplayAlert("Error", $"Failed to upload model:\n{ex.Message}", "OK");
             }
         }
 

--- a/MauiApp3.csproj
+++ b/MauiApp3.csproj
@@ -60,9 +60,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
 		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.1" />
+		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -21,6 +21,7 @@ namespace MauiApp3
 
             // Register services
             builder.Services.AddSingleton<Model3DService>();
+            builder.Services.AddSingleton<DatabaseService>();
             
             // Register ViewModels
             builder.Services.AddTransient<MainViewModel>();

--- a/Models/Model3DFileDb.cs
+++ b/Models/Model3DFileDb.cs
@@ -1,0 +1,35 @@
+using SQLite;
+
+namespace MauiApp3.Models
+{
+    /// <summary>
+    /// Database model for persisting 3D model metadata
+    /// </summary>
+    [Table("Models")]
+    public class Model3DFileDb
+    {
+        [PrimaryKey]
+        public string Id { get; set; } = string.Empty;
+        
+        public string Name { get; set; } = string.Empty;
+        
+        public string FilePath { get; set; } = string.Empty;
+        
+        public string FileType { get; set; } = string.Empty;
+        
+        public DateTime UploadedDate { get; set; }
+        
+        public long FileSize { get; set; }
+        
+        /// <summary>
+        /// Thumbnail stored as byte array (max 2MB)
+        /// </summary>
+        [MaxLength(2000000)]
+        public byte[]? ThumbnailData { get; set; }
+        
+        /// <summary>
+        /// Tags stored as comma-separated string for SQLite compatibility
+        /// </summary>
+        public string TagsString { get; set; } = string.Empty;
+    }
+}

--- a/Pages/ModelDetailPage.xaml.cs
+++ b/Pages/ModelDetailPage.xaml.cs
@@ -1,5 +1,6 @@
 using MauiApp3.Models;
 using MauiApp3.ViewModels;
+using CommunityToolkit.Mvvm.Messaging;
 
 namespace MauiApp3.Pages
 {
@@ -38,7 +39,7 @@ namespace MauiApp3.Pages
             }
 
             // Subscribe to reset view message
-            MessagingCenter.Subscribe<ModelDetailViewModel>(this, "ResetView", (sender) =>
+            WeakReferenceMessenger.Default.Register<ResetViewMessage>(this, (r, m) =>
             {
                 Model3DViewer.ResetView();
             });
@@ -47,7 +48,7 @@ namespace MauiApp3.Pages
         protected override void OnDisappearing()
         {
             base.OnDisappearing();
-            MessagingCenter.Unsubscribe<ModelDetailViewModel>(this, "ResetView");
+            WeakReferenceMessenger.Default.Unregister<ResetViewMessage>(this);
         }
     }
 }

--- a/Platforms/Android/AndroidManifest.xml
+++ b/Platforms/Android/AndroidManifest.xml
@@ -3,4 +3,7 @@
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 </manifest>

--- a/Services/DatabaseService.cs
+++ b/Services/DatabaseService.cs
@@ -1,0 +1,218 @@
+using SQLite;
+using MauiApp3.Models;
+using System.Collections.ObjectModel;
+
+namespace MauiApp3.Services
+{
+    /// <summary>
+    /// SQLite database service for persisting 3D model metadata
+    /// </summary>
+    public class DatabaseService
+    {
+        private SQLiteAsyncConnection? _database;
+        private readonly string _dbPath;
+
+        public DatabaseService()
+        {
+            _dbPath = Path.Combine(FileSystem.AppDataDirectory, "models.db3");
+        }
+
+        /// <summary>
+        /// Initialize database connection and create tables
+        /// </summary>
+        private async Task InitAsync()
+        {
+            if (_database != null)
+                return;
+
+            _database = new SQLiteAsyncConnection(_dbPath);
+            await _database.CreateTableAsync<Model3DFileDb>();
+        }
+
+        /// <summary>
+        /// Get all models from database
+        /// </summary>
+        public async Task<List<Model3DFile>> GetAllModelsAsync()
+        {
+            await InitAsync();
+            
+            var dbModels = await _database!.Table<Model3DFileDb>().ToListAsync();
+            
+            return dbModels.Select(ConvertToModel).ToList();
+        }
+
+        /// <summary>
+        /// Save or update a single model
+        /// </summary>
+        public async Task<int> SaveModelAsync(Model3DFile model)
+        {
+            await InitAsync();
+            
+            var dbModel = ConvertToDbModel(model);
+            
+            // Check if exists
+            var existing = await _database!.Table<Model3DFileDb>()
+                .Where(m => m.Id == model.Id)
+                .FirstOrDefaultAsync();
+
+            if (existing != null)
+            {
+                return await _database.UpdateAsync(dbModel);
+            }
+            else
+            {
+                return await _database.InsertAsync(dbModel);
+            }
+        }
+
+        /// <summary>
+        /// Save multiple models in a transaction
+        /// </summary>
+        public async Task<int> SaveAllModelsAsync(IEnumerable<Model3DFile> models)
+        {
+            await InitAsync();
+            
+            var dbModels = models.Select(ConvertToDbModel).ToList();
+            
+            return await _database!.InsertAllAsync(dbModels, runInTransaction: true);
+        }
+
+        /// <summary>
+        /// Delete a model from database
+        /// </summary>
+        public async Task<int> DeleteModelAsync(string modelId)
+        {
+            await InitAsync();
+            
+            return await _database!.Table<Model3DFileDb>()
+                .DeleteAsync(m => m.Id == modelId);
+        }
+
+        /// <summary>
+        /// Delete all models from database
+        /// </summary>
+        public async Task<int> DeleteAllModelsAsync()
+        {
+            await InitAsync();
+            
+            return await _database!.DeleteAllAsync<Model3DFileDb>();
+        }
+
+        /// <summary>
+        /// Get a single model by ID
+        /// </summary>
+        public async Task<Model3DFile?> GetModelByIdAsync(string modelId)
+        {
+            await InitAsync();
+            
+            var dbModel = await _database!.Table<Model3DFileDb>()
+                .Where(m => m.Id == modelId)
+                .FirstOrDefaultAsync();
+
+            return dbModel != null ? ConvertToModel(dbModel) : null;
+        }
+
+        /// <summary>
+        /// Search models by name or tags
+        /// </summary>
+        public async Task<List<Model3DFile>> SearchModelsAsync(string searchTerm)
+        {
+            await InitAsync();
+            
+            var lowerSearch = searchTerm.ToLower();
+            
+            var dbModels = await _database!.Table<Model3DFileDb>()
+                .Where(m => m.Name.ToLower().Contains(lowerSearch) || 
+                           m.TagsString.ToLower().Contains(lowerSearch))
+                .ToListAsync();
+
+            return dbModels.Select(ConvertToModel).ToList();
+        }
+
+        /// <summary>
+        /// Get models by file type
+        /// </summary>
+        public async Task<List<Model3DFile>> GetModelsByTypeAsync(string fileType)
+        {
+            await InitAsync();
+            
+            var dbModels = await _database!.Table<Model3DFileDb>()
+                .Where(m => m.FileType == fileType)
+                .ToListAsync();
+
+            return dbModels.Select(ConvertToModel).ToList();
+        }
+
+        /// <summary>
+        /// Get database statistics
+        /// </summary>
+        public async Task<(int totalModels, long totalSize, int totalTags)> GetStatisticsAsync()
+        {
+            await InitAsync();
+            
+            var models = await _database!.Table<Model3DFileDb>().ToListAsync();
+            
+            var totalModels = models.Count;
+            var totalSize = models.Sum(m => m.FileSize);
+            var allTags = models
+                .SelectMany(m => m.TagsString.Split(',', StringSplitOptions.RemoveEmptyEntries))
+                .Distinct()
+                .Count();
+
+            return (totalModels, totalSize, allTags);
+        }
+
+        /// <summary>
+        /// Convert database model to app model
+        /// </summary>
+        private Model3DFile ConvertToModel(Model3DFileDb dbModel)
+        {
+            var tags = string.IsNullOrEmpty(dbModel.TagsString)
+                ? new ObservableCollection<string>()
+                : new ObservableCollection<string>(
+                    dbModel.TagsString.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(t => t.Trim())
+                );
+
+            return new Model3DFile
+            {
+                Id = dbModel.Id,
+                Name = dbModel.Name,
+                FilePath = dbModel.FilePath,
+                FileType = dbModel.FileType,
+                UploadedDate = dbModel.UploadedDate,
+                FileSize = dbModel.FileSize,
+                ThumbnailData = dbModel.ThumbnailData,
+                Tags = tags
+                // ParsedModel will be loaded separately when needed
+            };
+        }
+
+        /// <summary>
+        /// Convert app model to database model
+        /// </summary>
+        private Model3DFileDb ConvertToDbModel(Model3DFile model)
+        {
+            var tagsString = model.Tags.Any()
+                ? string.Join(",", model.Tags)
+                : string.Empty;
+
+            return new Model3DFileDb
+            {
+                Id = model.Id,
+                Name = model.Name,
+                FilePath = model.FilePath,
+                FileType = model.FileType,
+                UploadedDate = model.UploadedDate,
+                FileSize = model.FileSize,
+                ThumbnailData = model.ThumbnailData,
+                TagsString = tagsString
+            };
+        }
+
+        /// <summary>
+        /// Get database file path (for debugging)
+        /// </summary>
+        public string GetDatabasePath() => _dbPath;
+    }
+}

--- a/Services/ThumbnailGenerator.cs
+++ b/Services/ThumbnailGenerator.cs
@@ -1,6 +1,5 @@
 using SkiaSharp;
 using System.Numerics;
-using MauiApp3.Services;
 
 namespace MauiApp3.Services
 {
@@ -17,8 +16,9 @@ namespace MauiApp3.Services
         // Cache for thumbnail generation
         private readonly SKPaint _fillPaint;
         private readonly SKPaint _borderPaint;
-        private readonly SKPaint _iconPaint;
-        private readonly SKPaint _typePaint;
+        private readonly SKFont _iconFont;
+        private readonly SKFont _typeFont;
+        private readonly SKPaint _textPaint;
 
         public ThumbnailGenerator()
         {
@@ -37,21 +37,18 @@ namespace MauiApp3.Services
                 IsAntialias = true
             };
 
-            _iconPaint = new SKPaint
+            // Use SKFont instead of obsolete SKPaint text properties
+            _iconFont = new SKFont
             {
-                Color = new SKColor(100, 100, 100),
-                TextSize = 60,
-                IsAntialias = true,
-                TextAlign = SKTextAlign.Center
+                Size = 60
             };
 
-            _typePaint = new SKPaint
+            var boldTypeface = SKTypeface.FromFamilyName("Arial", SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
+            _typeFont = new SKFont(boldTypeface, 16);
+
+            _textPaint = new SKPaint
             {
-                Color = new SKColor(0, 120, 212),
-                TextSize = 16,
-                IsAntialias = true,
-                TextAlign = SKTextAlign.Center,
-                Typeface = SKTypeface.FromFamilyName("Arial", SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright)
+                IsAntialias = true
             };
         }
 
@@ -171,10 +168,12 @@ namespace MauiApp3.Services
             canvas.Clear(new SKColor(30, 30, 30));
 
             // Draw centered icon
-            canvas.DrawText("??", width * 0.5f, height * 0.5f + 20, _iconPaint);
+            _textPaint.Color = new SKColor(100, 100, 100);
+            canvas.DrawText("??", width * 0.5f, height * 0.5f + 20, SKTextAlign.Center, _iconFont, _textPaint);
 
             // Draw file type
-            canvas.DrawText(fileType, width * 0.5f, height - 20, _typePaint);
+            _textPaint.Color = new SKColor(0, 120, 212);
+            canvas.DrawText(fileType, width * 0.5f, height - 20, SKTextAlign.Center, _typeFont, _textPaint);
 
             // Convert to byte array
             using var image = surface.Snapshot();

--- a/ViewModels/ModelDetailViewModel.cs
+++ b/ViewModels/ModelDetailViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Messaging;
 
 namespace MauiApp3.ViewModels
 {
@@ -78,8 +79,8 @@ namespace MauiApp3.ViewModels
 
         private void ResetView()
         {
-            // This will be handled by the page's code-behind
-            MessagingCenter.Send(this, "ResetView");
+            // Send message to page to reset view
+            WeakReferenceMessenger.Default.Send(new ResetViewMessage());
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -88,5 +89,10 @@ namespace MauiApp3.ViewModels
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+    }
+
+    // Message for resetting the view
+    public class ResetViewMessage
+    {
     }
 }


### PR DESCRIPTION
This pull request introduces several important improvements to the 3D model viewer application, focusing on enabling persistent storage of model metadata, improving file upload handling, and updating dependencies. The main changes include the addition of a new SQLite-based database service for storing model information, refactoring the upload workflow to directly handle file selection and parsing, updating permissions and dependencies for database support, and making minor UI and code improvements.

**Persistent storage and database integration:**

* Added a new `DatabaseService` class implementing SQLite-based persistence for 3D model metadata, including CRUD operations, search, statistics, and conversion between app and database models.
* Introduced a new `Model3DFileDb` class representing the database schema for models, including fields for metadata and thumbnail storage.
* Registered `DatabaseService` as a singleton in the app startup (`MauiProgram.cs`).
* Added necessary NuGet package references for SQLite support in the project file (`MauiApp3.csproj`).
* Updated Android manifest to request external storage permissions for file access.

**File upload workflow refactor:**

* Replaced XAML command bindings for model upload buttons with direct event handlers, and implemented a new `OnUploadButtonClicked` method for file picking, validation, parsing, thumbnail generation, and database saving, with improved error handling and logging. [[1]](diffhunk://#diff-f14082a0c1cad95355396d35b83d65194bf99eaf44619740e72eb101a27121cfL83-R83) [[2]](diffhunk://#diff-f14082a0c1cad95355396d35b83d65194bf99eaf44619740e72eb101a27121cfL310-R310) [[3]](diffhunk://#diff-9795c74bb366e66e878b2c4703bd50b424ff9c76dac184d2cc1cf175b7358533R48-R164) [[4]](diffhunk://#diff-9795c74bb366e66e878b2c4703bd50b424ff9c76dac184d2cc1cf175b7358533R16-R19)

**Messaging and UI improvements:**

* Migrated from `MessagingCenter` to `WeakReferenceMessenger` for view reset notifications in model detail pages, improving reliability and code clarity. [[1]](diffhunk://#diff-6cb05e5e25b3d1ac727d062b33ee2022f15d71ae42e9274aad28d143fdb06301R3) [[2]](diffhunk://#diff-6cb05e5e25b3d1ac727d062b33ee2022f15d71ae42e9274aad28d143fdb06301L41-R42) [[3]](diffhunk://#diff-6cb05e5e25b3d1ac727d062b33ee2022f15d71ae42e9274aad28d143fdb06301L50-R51)
* Updated axis indicator rendering in the 3D viewer to use `SKFont` for text drawing, for better appearance and consistency. [[1]](diffhunk://#diff-5192926acff04067e943640cb0f4bdf5c47aa391ed37790b419b1bbe80acc92bR217-R224) [[2]](diffhunk://#diff-5192926acff04067e943640cb0f4bdf5c47aa391ed37790b419b1bbe80acc92bL234-R235)
* Minor refactorings in the 3D viewer touch handling logic and thumbnail generator code for clarity and performance. [[1]](diffhunk://#diff-5192926acff04067e943640cb0f4bdf5c47aa391ed37790b419b1bbe80acc92bL19) [[2]](diffhunk://#diff-5192926acff04067e943640cb0f4bdf5c47aa391ed37790b419b1bbe80acc92bL79) [[3]](diffhunk://#diff-35a28e1d2451eb465315678c11d09c1b5310f992507127b56dc71ab4526f218cL3) [[4]](diffhunk://#diff-35a28e1d2451eb465315678c11d09c1b5310f992507127b56dc71ab4526f218cL20-R21)